### PR TITLE
chore: release v0.0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2731,7 +2731,7 @@ dependencies = [
 
 [[package]]
 name = "lynx-cli"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -2745,7 +2745,7 @@ dependencies = [
 
 [[package]]
 name = "lynx-core"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -2794,7 +2794,7 @@ dependencies = [
 
 [[package]]
 name = "lynx-proxy"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/lynx-core", "crates/lynx-proxy/src-tauri", "crates/lynx-cli"]
 resolver = "2"
 
 [workspace.package]
-version = "0.0.2"
+version = "0.0.3"
 authors = ["suxin2017"]
 description = "A proxy service"
 edition = "2021"

--- a/crates/lynx-cli/Cargo.toml
+++ b/crates/lynx-cli/Cargo.toml
@@ -11,7 +11,7 @@ repository.workspace = true
 include = ["src", "Cargo.toml", "README.md", "asserts"]
 
 [dependencies]
-lynx-core = { version = "0.0.2", path = "../lynx-core" }
+lynx-core = { version = "0.0.3", path = "../lynx-core" }
 tracing-subscriber = { workspace = true }
 tracing = { workspace = true }
 anyhow = { workspace = true }


### PR DESCRIPTION



## 🤖 New release

* `lynx-core`: 0.0.2 -> 0.0.3 (✓ API compatible changes)
* `lynx-cli`: 0.0.2 -> 0.0.3

<details><summary><i><b>Changelog</b></i></summary><p>

## `lynx-core`

<blockquote>

## [0.0.3](https://github.com/suxin2017/lynx/compare/lynx-core-v0.0.2...lynx-core-v0.0.3) - 2025-02-12

### Fixed

- dep

### Other

- release v0.0.3 (#23)
</blockquote>

## `lynx-cli`

<blockquote>

## [0.0.3](https://github.com/suxin2017/lynx/compare/v0.0.2...v0.0.3) - 2025-02-12

### Other

- release ci (#22)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).