### PR TITLE
chore: release v0.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.0.4](https://github.com/suxin2017/lynx/compare/lynx-cli-v0.0.3...lynx-cli-v0.0.4) - 2025-02-13
+
+### Fixed
+
+- some thing
+
+### Other
+
+- changelog

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6773,9 +6773,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "window-vibrancy"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ea403deff7b51fff19e261330f71608ff2cdef5721d72b64180bb95be7c4150"
+checksum = "831ad7678290beae36be6f9fad9234139c7f00f3b536347de7745621716be82d"
 dependencies = [
  "objc2",
  "objc2-app-kit",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/lynx-core", "crates/lynx-proxy/src-tauri", "crates/lynx-cli"]
 resolver = "2"
 
 [workspace.package]
-version = "0.0.3"
+version = "0.0.4"
 authors = ["suxin2017"]
 description = "A proxy service"
 edition = "2021"

--- a/crates/lynx-cli/Cargo.toml
+++ b/crates/lynx-cli/Cargo.toml
@@ -11,7 +11,7 @@ repository.workspace = true
 include = ["src", "Cargo.toml", "README.md", "asserts"]
 
 [dependencies]
-lynx-core = { version = "0.0.3", path = "../lynx-core" }
+lynx-core = { version = "0.0.4", path = "../lynx-core" }
 tracing-subscriber = { workspace = true }
 tracing = { workspace = true }
 anyhow = { workspace = true }


### PR DESCRIPTION



## 🤖 New release

* `lynx-core`: 0.0.3 -> 0.0.4
* `lynx-cli`: 0.0.3 -> 0.0.4

<details><summary><i><b>Changelog</b></i></summary><p>


## `lynx-cli`

<blockquote>

## [0.0.4](https://github.com/suxin2017/lynx/compare/lynx-cli-v0.0.3...lynx-cli-v0.0.4) - 2025-02-13

### Fixed

- some thing

### Other

- changelog
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).